### PR TITLE
test for basic functionality

### DIFF
--- a/test/test_timeout.rb
+++ b/test/test_timeout.rb
@@ -3,6 +3,13 @@ require 'test/unit'
 require 'timeout'
 
 class TestTimeout < Test::Unit::TestCase
+
+  def test_non_timing_out_code_is_successful
+    assert_nothing_raised do
+      assert_equal :ok, Timeout.timeout(1){ :ok }
+    end
+  end
+
   def test_queue
     q = Thread::Queue.new
     assert_raise(Timeout::Error, "[ruby-dev:32935]") {


### PR DESCRIPTION
The only other test for return value and not timing out is
within test_custom_exception bug9354 case,
which includes a custom exception.

Seems like a good idea to cover the basic case without
a custom exception as well.